### PR TITLE
Cursor settings pane minimum width

### DIFF
--- a/app/css/layout.scss
+++ b/app/css/layout.scss
@@ -39,6 +39,10 @@ hr {
     height: 100%;
     border-left: 1px solid gray;
     overflow-y: scroll;
-    overflow-x: hidden;
+    overflow-x: auto;
     color: white;
+}
+
+.sidebar > * {
+    min-width: 700px;
 }


### PR DESCRIPTION
Add a 700px minimum width to the cursor settings pane to enable horizontal scrolling instead of layout collapse.

---
<p><a href="https://cursor.com/agents/bc-b78266a4-e9b9-4395-9d20-d1e8ec1c52e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b78266a4-e9b9-4395-9d20-d1e8ec1c52e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

